### PR TITLE
feature/workflows_flake8_black

### DIFF
--- a/workflows/black.yml
+++ b/workflows/black.yml
@@ -1,36 +1,26 @@
 name: black
-on: pull_request
+on: [pull_request]
 jobs:
-  black:
-    # Check if the PR is not raised by this workflow and is not from a fork
-    if: startsWith(github.head_ref, 'black-patches') == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-20.04
+  linter_name:
+    name: runner / black
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-         with:
-          ref: ${{ github.head_ref }}
-      - name: black
-        uses: actions/setup-python@v1
+      - name: Check files using the black formatter
+        uses: rickstaa/action-black@v1
+        id: action_black
         with:
-          python-version: 3.8
-        run: |
-          python -m pip install --upgrade pip
-          pip install black
-        run: |
-          black --experimental-string-processing .
+          black_args: ". --experimental-string-processing"
       - name: Set black branch name
         id: vars
         run: echo ::set-output name=branch-name::"black-patches/${{ github.head_ref }}"
       - name: Create Pull Request
-        if: steps.black.outputs.exit-code == 2
+        if: startsWith(github.head_ref, 'black-patches') == false && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-pull-request@v3
         with:
           commit-message: black action fixes
           title: Fixes by black action
           body: This is an auto-generated PR with fixes by black.
           labels: black, automated pr
-          reviewers: peter-evans
+          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
           branch: ${{ steps.vars.outputs.branch-name }}
-      - name: Fail if black made changes
-        if: steps.black.outputs.exit-code == 2
-        run: exit 1

--- a/workflows/flake8.yml
+++ b/workflows/flake8.yml
@@ -1,0 +1,20 @@
+name: Flake8
+
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: Analysing the code with flake8
+      run: |
+        flake8 $(git ls-files '*.py') --max-line-length 88 --show-source


### PR DESCRIPTION
# Description

./workflows/flake8.yml
  - Unified writing style into black.yml
./workflows/black.yml
  - fixed autopep8 specification section
# Context
-  flake8 and black to run when pull req automatically [WIP]
# Checklist

- [x] I opened a draft PR or added the `[WIP]` level if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [x] I have assigned an appropriate reviewer for the PR.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes
Test:

- Confirmed that both flake8 and black workflows runned when creating PR (in [pj_blockchain]
(https://github.com/TISSIS-bc/pj_blockchain/pull/4)

<img width="968" alt="image" src="https://user-images.githubusercontent.com/49639555/183278148-db10af84-9722-47db-84a6-aa74b7028088.png">

<img width="1257" alt="image" src="https://user-images.githubusercontent.com/49639555/183278139-c9ab9a9c-dc49-46cc-aa91-342086511663.png">




- [x] TODO:https://stackoverflow.com/questions/72376229/github-actions-is-not-permitted-to-create-or-approve-pull-requests-createpullre

こちら対応お願いいたします @terapoon  (organizationの設定)
